### PR TITLE
added patch to fix build

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -8,7 +8,7 @@
 \usepackage[hidelinks]{hyperref}
 \usepackage{showlabels}
 \usepackage{lineno}
-\linenumbers\
+\linenumbers
 
 \newtheorem{lemma}{Lemma}
 \newtheorem{prop}{Proposition}


### PR DESCRIPTION
currently the "/"  in line 11 of main.tex ruins the build for me:

```
LaTeX Warning: Citation `Felsenstein1981-zs' on page 2 undefined on input line 
45.

No file main.bbl.
[2] (./main.aux)

Package rerunfilecheck Warning: File `main.out' has changed.
(rerunfilecheck)                Rerun to get outlines right
(rerunfilecheck)                or use package `bookmark'.


LaTeX Warning: There were undefined references.

 )
(see the transcript file for additional information)</usr/share/texlive/texmf-d
ist/fonts/type1/public/amsfonts/cm/cmbx10.pfb></usr/share/texlive/texmf-dist/fo
nts/type1/public/amsfonts/cm/cmbx12.pfb></usr/share/texlive/texmf-dist/fonts/ty
pe1/public/amsfonts/cm/cmbx9.pfb></usr/share/texlive/texmf-dist/fonts/type1/pub
lic/amsfonts/cm/cmr10.pfb></usr/share/texlive/texmf-dist/fonts/type1/public/ams
fonts/cm/cmr12.pfb></usr/share/texlive/texmf-dist/fonts/type1/public/amsfonts/c
m/cmr17.pfb></usr/share/texlive/texmf-dist/fonts/type1/public/amsfonts/cm/cmr9.
pfb></usr/share/texlive/texmf-dist/fonts/type1/public/amsfonts/cm/cmss8.pfb>
Output written on main.pdf (2 pages, 74149 bytes).
Transcript written on main.log.
pdflatex returned an error, check the log file
scons: *** [_build/main.pdf] Error 1
scons: building terminated because of errors.
```

here's the patch.